### PR TITLE
Use ROR for copyright holder, drop email

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gcube: Simulating Biodiversity Data Cubes",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "upload_type": "software",
   "description": "<p>This R package provides a simulation framework for biodiversity data cubes. This can start from simulating multiple species distributed in a landscape over a temporal scope. In a second phase, the simulation of a variety of observation processes and effort can generate actual occurrence datasets. Based on their (simulated) spatial uncertainty, occurrences can then be designated to a grid to form a data cube.<\/p>",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,4 +32,4 @@ identifiers:
   value: 10.5281/zenodo.14038996
 - type: url
   value: https://b-cubed-eu.github.io/gcube/
-version: 1.3.4
+version: 1.3.5

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gcube
 Title: Simulating Biodiversity Data Cubes
-Version: 1.3.4
+Version: 1.3.5
 Authors@R: c(
     person("Ward", "Langeraert", , "ward.langeraert@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5900-8109", affiliation = "Research Institute for Nature and Forest (INBO)")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-4291-5981")),
     person("Mukhtar Muhammed", "Yahaya", role = "ctb",
            comment = c(ORCID = "0009-0008-9200-0863")),
-    person("Research Institute for Nature and Forest (INBO)", , , "info@inbo.be", role = "cph"),
+    person("Research Institute for Nature and Forest (INBO)", role = "cph",
+           comment = c(ROR = "00j54wy13")),
     person("European Union's Horizon Europe Research and Innovation Programme (ID No 101059592)", role = "fnd")
   )
 Description: This R package provides a simulation framework for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gcube 1.3.5
+
+* Use ROR for copyright holder
+
 # gcube 1.3.4
 
 * Fix NEWS file

--- a/checklist.yml
+++ b/checklist.yml
@@ -1,7 +1,12 @@
 description: Configuration file for checklist::check_pkg()
 package: yes
 allowed:
-  warnings: []
+  warnings:
+  - motivation: Bug checklist
+    value: '`Research Institute for Nature and Forest (INBO)` must be listed as copyright
+      holder and use `info@inbo.be` as email.'
+  - motivation: Not applicable
+    value: ORCID required for `Research Institute for Nature and Forest (INBO)`
   notes:
   - motivation: This is just a note that reminds CRAN maintainers to check that the
       submission comes actually from his maintainer and not anybody else.

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/b-cubed-eu/gcube",
   "issueTracker": "https://github.com/b-cubed-eu/gcube/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -107,8 +107,7 @@
   "copyrightHolder": [
     {
       "@type": "Organization",
-      "name": "Research Institute for Nature and Forest (INBO)",
-      "email": "info@inbo.be"
+      "name": "Research Institute for Nature and Forest (INBO)"
     }
   ],
   "funder": [
@@ -370,7 +369,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "576.153KB",
+  "fileSize": "576.295KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -382,7 +381,7 @@
           "familyName": "Langeraert"
         }
       },
-      "name": "gcube: Simulating Biodiversity Data Cubes. Version 1.3.4",
+      "name": "gcube: Simulating Biodiversity Data Cubes. Version 1.3.5",
       "identifier": "10.5281/zenodo.14038996",
       "url": "https://b-cubed-eu.github.io/gcube/",
       "@id": "https://doi.org/10.5281/zenodo.14038996",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -2,12 +2,12 @@ citHeader("To cite `gcube` in publications please use:")
 # begin checklist entry
 bibentry(
   bibtype = "Manual",
-  title = "gcube: Simulating Biodiversity Data Cubes. Version 1.3.4",
+  title = "gcube: Simulating Biodiversity Data Cubes. Version 1.3.5",
   author = c( author = c(person(given = "Ward", family = "Langeraert"))),
   year = 2025,
   url = "https://b-cubed-eu.github.io/gcube/",
   abstract = "This R package provides a simulation framework for biodiversity data cubes. This can start from simulating multiple species distributed in a landscape over a temporal scope. In a second phase, the simulation of a variety of observation processes and effort can generate actual occurrence datasets. Based on their (simulated) spatial uncertainty, occurrences can then be designated to a grid to form a data cube.",
-  textVersion = "Langeraert, Ward (2025) gcube: Simulating Biodiversity Data Cubes. Version 1.3.4. https://b-cubed-eu.github.io/gcube/",
+  textVersion = "Langeraert, Ward (2025) gcube: Simulating Biodiversity Data Cubes. Version 1.3.5. https://b-cubed-eu.github.io/gcube/",
   keywords = "simulation; data cubes; B-Cubed; biodiversity; Monte-Carlo",
   doi = "10.5281/zenodo.14038996",
 )

--- a/inst/en_gb.dic
+++ b/inst/en_gb.dic
@@ -1,4 +1,3 @@
-
 ️
 CMD
 CRS
@@ -6,6 +5,7 @@ EEA
 LAEA
 MGRS
 Palearctic
+ROR
 SpatRaster
 WGS
 WorldClim


### PR DESCRIPTION
[pkgdown 2.1.2](https://github.com/r-lib/pkgdown/releases/tag/v2.1.2) now supports ROR Identifiers for organizations. Since this supports better linked data, I think we should adopt it for our packages.

It will display on the pkgdown website as:

<img width="585" alt="Screenshot 2025-04-28 at 15 13 10" src="https://github.com/user-attachments/assets/3b4f44a8-760a-4316-9d37-9813b3792fa5" />

It might take a bit until GitHub Actions use pkgdown 2.1.2, so it will currently display as:

<img width="539" alt="Screenshot 2025-04-28 at 15 13 23" src="https://github.com/user-attachments/assets/13544ffe-b62a-4392-a99d-a82a9b8048a8" />

Eventually, this will resolve itself on future builds.

Note: I have also removed the org email address, since I don't think it is very useful.
